### PR TITLE
[Fix] text_areaを修正する

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,7 +10,7 @@
   <div class="field">
     <p>
       <strong>本文:</strong><br/>
-      <%= @article.body %>
+      <%= safe_join(@article.body.split("\n"),tag(:br)) %>
     </p>
   </div>
   <div class="field">


### PR DESCRIPTION
## 問題
記事詳細画面の本文にスペースや改行が反映されない

## 内容
本文の表示箇所を<%= safe_join(@article.body.split("\n"),tag(:br)) %>に修正する
