### PR TITLE
[Fix] バリデーションエラーを修正する

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,8 +2,6 @@ class Article < ApplicationRecord
   with_options presence: true do
     validates :title
     validates :body
-    validates :member_id
-    validates :category_id
   end
 
   belongs_to :member

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,7 +4,5 @@ class Comment < ApplicationRecord
 
   with_options presence: true do
     validates :content
-    validates :article_id
-    validates :member_id
   end
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,10 +1,9 @@
 <%= form_with(model: article, local: true) do |form| %>
   <% if article.errors.any? %>
     <div id="error_explanation">
-    <% messages = article.errors.full_messages.select { |msg| !msg.match?(/\w.+/) } %>
-    <h2><%= messages.count %>件のエラーのため記事が保存できませんでした。</h2>
+    <h2><%= article.errors.count %>件のエラーのため記事が保存できませんでした。</h2>
       <ul class="error_message">
-      <% messages.each do |message| %>
+      <% article.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
       </ul>

--- a/db/migrate/20200625115831_devise_create_members.rb
+++ b/db/migrate/20200625115831_devise_create_members.rb
@@ -33,9 +33,9 @@ class DeviseCreateMembers < ActiveRecord::Migration[5.2]
       # t.datetime :locked_at
 
       t.string :name, null: false
-      t.integer :school_year, null: false, default: 0, limit: 1
+      t.integer :school_year, default: 0
       t.string :profile_image_id
-      t.boolean :is_deleted, null: false, default: false
+      t.boolean :is_deleted, default: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20200627080018_create_articles.rb
+++ b/db/migrate/20200627080018_create_articles.rb
@@ -3,8 +3,8 @@ class CreateArticles < ActiveRecord::Migration[5.2]
     create_table :articles do |t|
       t.string :title, null: false
       t.text :body, null: false
-      t.integer :member_id, null: false
-      t.integer :category_id, null: false
+      t.integer :member_id
+      t.integer :category_id
       t.timestamps
     end
   end

--- a/db/migrate/20200630061953_create_categories.rb
+++ b/db/migrate/20200630061953_create_categories.rb
@@ -2,7 +2,7 @@ class CreateCategories < ActiveRecord::Migration[5.2]
   def change
     create_table :categories do |t|
       t.string :name, null: false
-      t.boolean :is_invalid, null: false, default: false
+      t.boolean :is_invalid, default: false
       t.timestamps
     end
   end

--- a/db/migrate/20200630105945_create_comments.rb
+++ b/db/migrate/20200630105945_create_comments.rb
@@ -2,8 +2,8 @@ class CreateComments < ActiveRecord::Migration[5.2]
   def change
     create_table :comments do |t|
       t.text :content, null: false
-      t.integer :member_id, null: false
-      t.integer :article_id, null: false
+      t.integer :member_id
+      t.integer :article_id
 
       t.timestamps
     end

--- a/db/migrate/20200701070710_create_favorites.rb
+++ b/db/migrate/20200701070710_create_favorites.rb
@@ -1,8 +1,8 @@
 class CreateFavorites < ActiveRecord::Migration[5.2]
   def change
     create_table :favorites do |t|
-      t.integer :member_id, null: false
-      t.integer :article_id, null: false
+      t.integer :member_id
+      t.integer :article_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,30 +41,30 @@ ActiveRecord::Schema.define(version: 2020_07_01_070710) do
   create_table "articles", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
-    t.integer "member_id", null: false
-    t.integer "category_id", null: false
+    t.integer "member_id"
+    t.integer "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
-    t.boolean "is_invalid", default: false, null: false
+    t.boolean "is_invalid", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "comments", force: :cascade do |t|
     t.text "content", null: false
-    t.integer "member_id", null: false
-    t.integer "article_id", null: false
+    t.integer "member_id"
+    t.integer "article_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "favorites", force: :cascade do |t|
-    t.integer "member_id", null: false
-    t.integer "article_id", null: false
+    t.integer "member_id"
+    t.integer "article_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -76,9 +76,9 @@ ActiveRecord::Schema.define(version: 2020_07_01_070710) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "name", null: false
-    t.integer "school_year", limit: 1, default: 0, null: false
+    t.integer "school_year", default: 0
     t.string "profile_image_id"
-    t.boolean "is_deleted", default: false, null: false
+    t.boolean "is_deleted", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_members_on_email", unique: true


### PR DESCRIPTION
## 問題
- 投稿に失敗すると「categoryを入力してください」のエラーメッセージが2つ出る

## 内容
- Articleモデルに記述していた「:category_id, presence: true」を削除
- migrateファイルの「null: false」を削除
- db:drop, db:migrateを実行
- Commentモデル、Favoriteモデルも同様の処理
- 「belongs_to :member、belongs_to :category」とあれば「null: false」は不要らしい