### PR TITLE
[Fix] メンバー一覧と記事一覧のカードの色を区別する

### DIFF
--- a/app/assets/stylesheets/members.scss
+++ b/app/assets/stylesheets/members.scss
@@ -14,11 +14,28 @@
 	padding: 100px
 }
 
-.member-content span {
+.member-underline span {
 	font-size: 30px;
 	background: linear-gradient(transparent 70%, #e4ab5a 70%)
 }
 
-.content > div {
+.member-main {
+    display: flex;
+    justify-content: center
+}
+
+.member-content {
+	padding: 20px;
+	max-width: 700px;
+	flex-grow: 1;
+	display: flex;
+	flex-wrap: wrap
+}
+
+.member-content > div {
 	border: thin solid #e4ab5a;
+	flex-basis:200px;
+	height: 250px;
+	margin: 10px;
+	position: relative
 }

--- a/app/views/members/_index.html.erb
+++ b/app/views/members/_index.html.erb
@@ -1,5 +1,5 @@
-<div class="main">
-  <div class="content">
+<div class="member-main">
+  <div class="member-content">
     <% members.each do |member| %>
       <div class="card box">
       <%= link_to member, style: "color: black;" do %>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-center">
 <div class="col-8">
-  <p class="member-content"><span>メンバー一覧(全<%= @members_all.count %>件)</span></p>
+  <p class="member-underline"><span>メンバー一覧(全<%= @members_all.count %>件)</span></p>
   <%= render 'index', members: @members %>
   <%= paginate @members %>
 


### PR DESCRIPTION
## 問題
メンバー一覧と記事一覧のカードの枠線の色が同じ

## 内容
members/_indexとarticles_indexでclass名を区別しcssで色指定