### PR TITLE
[Fix] コメントの表示を修正する

### DIFF
--- a/app/views/articles/_comment.html.erb
+++ b/app/views/articles/_comment.html.erb
@@ -13,7 +13,7 @@
 	    <% end %>
 	  </div>
 
-	  <div><%= comment.content %></div><br />
+	  <div><%= safe_join(comment.content.split("\n"),tag(:br)) %></div><br />
 	</li>
 	<% end %>
 </ol>


### PR DESCRIPTION
## 問題
コメントの改行が反映されない

## 内容
<%= safe_join(comment.content.split("\n"),tag(:br)) %>と修正