### PR TITLE
[Fix] deviseのエラーメッセージを修正する

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,11 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2>
+    <h3>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    </h3>
     <ul class="error_message">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -56,8 +56,8 @@ ja:
       not_found: 'は見つかりませんでした。'
       not_locked: 'は凍結されていません。'
       not_saved:
-        one: "エラーが発生したため %{resource} は保存されませんでした:"
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"
+        one: "エラーが発生したため %{resource} は保存されませんでした。"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
 
   activerecord:
     models:


### PR DESCRIPTION
## 問題
deviseのエラーメッセージが赤字で表示されない

## 内容
* ビュー
 * タグを`h2`から`h3`に変更
```
<h3>
      <%= I18n.t("errors.messages.not_saved",
                 count: resource.errors.count,
                 resource: resource.class.model_name.human.downcase)
       %>
</h3>
```