### PR TITLE
[Fix] 退会機能のコードを修正する

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -39,6 +39,6 @@ class Member < ApplicationRecord
   }
 
   def active_for_authentication?
-    super && (self.is_deleted == false)
+    super && (!self.is_deleted)
   end
 end

--- a/app/views/members/confirm.html.erb
+++ b/app/views/members/confirm.html.erb
@@ -5,7 +5,7 @@
 	再度ご利用いただくには、メンバー登録が必要となります。</p>
 
 	<div class="mx-auto" style="width: 328px;">
-		<%= link_to "やっぱり退会しない", 'javascript:history.back()', class: "btn btn-default" %>
-		<%= link_to "それでも退会する", hide_member_path(current_member), method: :patch, "data-confirm" => "本当に退会しますか？", class: "btn btn-default" %>
+		<%= link_to "やっぱり退会しない", 'javascript:history.back()' %>　｜　
+		<%= link_to "それでも退会する", hide_member_path(current_member), method: :patch, "data-confirm" => "本当に退会しますか？" %>
 	</div>
 </div>


### PR DESCRIPTION
* 問題
条件文がわかりにくい

* 内容
  * 退会済みメンバーをログインさせないようにするコードを変更
    * `self.is_deleted==false` => `!self.is_deleted`
  * ビュー
    * 退会ボタンのclassを削除